### PR TITLE
Allow multiple X509Certificates with the same subjectDN

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/x509store/Certificate.java
+++ b/src/main/java/org/jruby/ext/openssl/x509store/Certificate.java
@@ -54,7 +54,9 @@ public class Certificate extends X509Object {
     public boolean matches(final X509Object other) {
         if (other instanceof Certificate) {
             final Certificate that = (Certificate) other;
-            return X509AuxCertificate.equalSubjects(this.x509, that.x509);
+            if (X509AuxCertificate.equalSubjects(this.x509, that.x509)) {
+                return this.x509.hashCode() == that.x509.hashCode();
+            };
         }
         return false;
     }


### PR DESCRIPTION
## Description
The current implementation of [OpenSSL::X509::Store](https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/X509/Store.html) in jruby-openssl does not allow multiple X509Certificates with the same SubjectDN (see [Certificate.java#L57](https://github.com/jruby/jruby-openssl/blob/6f91360cafa489ca23055bcdf5d49e6c56aa2018/src/main/java/org/jruby/ext/openssl/x509store/Certificate.java#L57)). This differs from the [C implementation](https://github.com/openbsd/src/blob/8d6bc8b3e8c3426e6a399728334939c60ac42a0d/lib/libcrypto/x509/x509_lu.c#L652). This may be tested by adding two certificates with the same SubjectDN to a OpenSSL::X509::Store and executing `verify` on certificate signed by one of them. It will work in CRuby and will not work in JRuby depending on the order the certificates are added.

## Changes
The `matches` method of Certificate was updated to compare on [hashCode()](https://docs.oracle.com/javase/7/docs/api/java/security/cert/Certificate.html#hashCode()). 
Because [getFirstIssuer()](https://github.com/jruby/jruby-openssl/blob/6f91360cafa489ca23055bcdf5d49e6c56aa2018/src/main/java/org/jruby/ext/openssl/x509store/StoreContext.java#L169) expects a grouping based on SubjectX500Principal of the certificate objects in the store, this was implemented, too.

## How this was tested
I tested if this change will allow the usage of multiple certificates with the same subjectdn on windows and linux. More tests are probably necessary.